### PR TITLE
指定した todo の詳細を JSON 形式で取得できるようにする

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -10,6 +10,11 @@ class TodosController < ApplicationController
     render json: todo, status: :created
   end
 
+  def show
+    todo = Todo.find(params[:id])
+    render json: todo
+  end
+
   private
 
   def todo_params

--- a/spec/requests/todo_spec.rb
+++ b/spec/requests/todo_spec.rb
@@ -64,4 +64,28 @@ RSpec.describe TodosController, type: :request do
       expect { post '/todos', params: params }.to change { Todo.count }.by(1)
     end
   end
+
+  describe 'GET #show' do
+    let!(:todo) { FactoryBot.create(:todo) }
+
+    it 'HTTP ステータスコード 200 を返すこと' do
+      get "/todos/#{todo.id}"
+      expect(response.status).to eq 200
+    end
+
+    it '指定した todo の内容を正しく JSON 形式で返すこと' do
+      get "/todos/#{todo.id}"
+      json = JSON.parse(response.body)
+      expect(json['id']).to eq todo.id
+      expect(json['title']).to eq todo.title
+      expect(json['text']).to eq todo.text
+      expect(json['created_at']).to eq todo.created_at.as_json
+    end
+
+    it '返す JSON の keys が仕様通りであること' do
+      get "/todos/#{todo.id}"
+      json = JSON.parse(response.body)
+      expect(json.keys).to include('id', 'title', 'text', 'created_at')
+    end
+  end
 end

--- a/spec/requests/todo_spec.rb
+++ b/spec/requests/todo_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe TodosController, type: :request do
 
       it '作成した todo の内容を正しく JSON 形式で返すこと' do
         get '/todos'
-        jsons = JSON.parse(response.body)
-        expect(jsons[0]['id']).to eq todo.id
-        expect(jsons[0]['title']).to eq todo.title
-        expect(jsons[0]['text']).to eq todo.text
-        expect(jsons[0]['created_at']).to eq todo.created_at.as_json
+        json = JSON.parse(response.body)
+        expect(json[0]['id']).to eq todo.id
+        expect(json[0]['title']).to eq todo.title
+        expect(json[0]['text']).to eq todo.text
+        expect(json[0]['created_at']).to eq todo.created_at.as_json
       end
 
       it '返す JSON の keys が仕様通りであること' do
         get '/todos'
-        jsons = JSON.parse(response.body)
-        expect(jsons[0].keys).to include('id', 'title', 'text', 'created_at')
+        json = JSON.parse(response.body)
+        expect(json[0].keys).to include('id', 'title', 'text', 'created_at')
       end
     end
 
@@ -33,8 +33,8 @@ RSpec.describe TodosController, type: :request do
 
       it '3つの todo を JSON 形式で返すこと' do
         get '/todos'
-        jsons = JSON.parse(response.body)
-        expect(jsons.size).to eq 3
+        json = JSON.parse(response.body)
+        expect(json.size).to eq 3
       end
     end
   end

--- a/spec/requests/todo_spec.rb
+++ b/spec/requests/todo_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe TodosController, type: :request do
       it '返す JSON の keys が仕様通りであること' do
         get '/todos'
         json = JSON.parse(response.body)
-        expect(json[0].keys).to include('id', 'title', 'text', 'created_at')
+        expect(json[0].keys).to contain_exactly('id', 'title', 'text', 'created_at')
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe TodosController, type: :request do
     it '返す JSON の keys が仕様通りであること' do
       post '/todos', params: params
       json = JSON.parse(response.body)
-      expect(json.keys).to include('id', 'title', 'text', 'created_at')
+      expect(json.keys).to contain_exactly('id', 'title', 'text', 'created_at')
     end
 
     it 'todo が新規作成されること' do
@@ -85,7 +85,7 @@ RSpec.describe TodosController, type: :request do
     it '返す JSON の keys が仕様通りであること' do
       get "/todos/#{todo.id}"
       json = JSON.parse(response.body)
-      expect(json.keys).to include('id', 'title', 'text', 'created_at')
+      expect(json.keys).to contain_exactly('id', 'title', 'text', 'created_at')
     end
   end
 end


### PR DESCRIPTION
なぜやるか
---
Closes #5 

やったこと
---
- TodosController に `show` アクションを追加
- todo 詳細機能のテストを追加
  - Request spec に TodosController の `show` アクションのテストを追加

動作確認
---
1. `$ bin/setup` でアプリケーションを初期化 & 動作確認用の todo を作成
2. `$ bin/rails s`でサーバーを起動する
3. 以下の curl コマンドを実行し、 期待する値が返ってくることを確認する( `id` と `created_at` の値は変わります)

``` 
# POST /todos
$ curl -X POST "http://localhost:3000/todos" -H "Content-Type: application/json" -H "accept: application/json" -d '{"title":"todo_title", "text": "todo_text"}' | jq
{
  "id": "791a63ee-3013-4548-868d-b07cca66f7ff",
  "title": "todo_title",
  "text": "todo_text",
  "created_at": "2018-07-18T07:07:30.877Z"
}

# GET /todos/{todo_id} <- {todo_id} には POST して作られた todo の id を入れる、この例であれば '791a63ee-3013-4548-868d-b07cca66f7ff' が入るので以下のコマンドになる
$ curl -X GET "http://localhost:3000/todos/791a63ee-3013-4548-868d-b07cca66f7ff" -H "accept: application/json" | jq
{
  "id": "791a63ee-3013-4548-868d-b07cca66f7ff",
  "title": "todo_title",
  "text": "todo_text",
  "created_at": "2018-07-18T07:07:30.877Z"
}
```