### PR TITLE
todo を更新できるようにする

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -6,7 +6,7 @@ class TodosController < ApplicationController
 
   def create
     todo = Todo.new(todo_params)
-    todo.save
+    todo.save!
     render json: todo, status: :created
   end
 
@@ -17,7 +17,7 @@ class TodosController < ApplicationController
 
   def update
     todo = Todo.find(params[:id])
-    todo.update(todo_params)
+    todo.update!(todo_params)
     render json: todo
   end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -15,6 +15,12 @@ class TodosController < ApplicationController
     render json: todo
   end
 
+  def update
+    todo = Todo.find(params[:id])
+    todo.update(todo_params)
+    render json: todo
+  end
+
   private
 
   def todo_params

--- a/spec/requests/todo_spec.rb
+++ b/spec/requests/todo_spec.rb
@@ -88,4 +88,38 @@ RSpec.describe TodosController, type: :request do
       expect(json.keys).to contain_exactly('id', 'title', 'text', 'created_at')
     end
   end
+
+  describe 'PATCH #update' do
+    let(:params) { { title: 'updated_title', text: 'updated_text' } }
+
+    let!(:todo) { FactoryBot.create(:todo, title: 'todo_title', text: 'todo_text') }
+
+    it 'HTTP ステータスコード 200 を返すこと' do
+      patch "/todos/#{todo.id}", params: params
+      expect(response.status).to eq 200
+    end
+
+    it 'PATCH した title と text を正しく JSON 形式で返すこと' do
+      patch "/todos/#{todo.id}", params: params
+      json = JSON.parse(response.body)
+      expect(json['title']).to eq params[:title]
+      expect(json['text']).to eq params[:text]
+    end
+
+    it '返す JSON の keys が仕様通りであること' do
+      patch "/todos/#{todo.id}", params: params
+      json = JSON.parse(response.body)
+      expect(json.keys).to contain_exactly('id', 'title', 'text', 'created_at')
+    end
+
+    it 'todo の title が更新されること' do
+      expect { patch "/todos/#{todo.id}", params: params }
+        .to change { Todo.find(todo.id).title }.from(todo.title).to(params[:title])
+    end
+
+    it 'todo の text が更新されること' do
+      expect { patch "/todos/#{todo.id}", params: params }
+        .to change { Todo.find(todo.id).text }.from(todo.text).to(params[:text])
+    end
+  end
 end


### PR DESCRIPTION
なぜやるか
---
Closes #6 

やったこと
---
- TodosController に `update` アクションを追加
- todo 更新機能のテストを追加
  - Request spec に TodosController の `update` アクションのテストを追加

動作確認
---
1. `$ bin/setup` でアプリケーションを初期化 & 動作確認用の todo を作成
2. `$ bin/rails s`でサーバーを起動する
3. 以下の curl コマンドを実行し、 期待する値が返ってくることを確認する( `id` と `created_at` の値は変わります)

``` 
# POST /todos
$ curl -X POST "http://localhost:3000/todos" -H "Content-Type: application/json" -H "accept: application/json" -d '{"title":"todo_title", "text": "todo_text"}' | jq
{
  "id": "65d5d242-af61-43fd-9db2-fbfd46148365",
  "title": "todo_title",
  "text": "todo_text",
  "created_at": "2018-07-19T07:54:25.376Z"
}

# GET /todos/{todo_id} <- {todo_id} には POST して作られた todo の id を入れる、この例であれば '65d5d242-af61-43fd-9db2-fbfd46148365' が入るので以下のコマンドになる
$ curl -X GET "http://localhost:3000/todos/65d5d242-af61-43fd-9db2-fbfd46148365" -H "accept: application/json" | jq
{
  "id": "65d5d242-af61-43fd-9db2-fbfd46148365",
  "title": "todo_title",
  "text": "todo_text",
  "created_at": "2018-07-19T07:54:25.376Z"
}

# PATCH /todos/{todo_id} <- 同じく {todo_id} には POST して作られた todo の id を入れる
$ curl -X PATCH "http://localhost:3000/todos/65d5d242-af61-43fd-9db2-fbfd46148365" -H "Content-Type: application/json" -H "accept: application/json" -d '{"title":"updated_title", "text": "updated_text"}' | jq
{
  "id": "65d5d242-af61-43fd-9db2-fbfd46148365",
  "title": "updated_title",
  "text": "updated_text",
  "created_at": "2018-07-19T07:54:25.376Z"
}

# GET /todos/{todo_id} <- 同上
$ curl -X GET "http://localhost:3000/todos/65d5d242-af61-43fd-9db2-fbfd46148365" -H "accept: application/json" | jq
{
  "id": "65d5d242-af61-43fd-9db2-fbfd46148365",
  "title": "updated_title",
  "text": "updated_text",
  "created_at": "2018-07-19T07:54:25.376Z"
}
```

その他
---
- 堅牢なアプリケーションを作るのであれば `#update!` とすべきところを `#update` としているのは https://github.com/daido1976/simple-todo-api/pull/10#discussion_r203918916 のような意図があってそうしています！