### PR TITLE
CORS を有効にする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'active_model_serializers'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
+gem 'rack-cors'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
       pry (>= 0.10.4)
     puma (3.11.4)
     rack (2.0.5)
+    rack-cors (1.0.2)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.2.0)
@@ -204,6 +205,7 @@ DEPENDENCIES
   pry-doc
   pry-rails
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.0)
   rspec-rails
   rubocop (= 0.55.0)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end


### PR DESCRIPTION
なぜやるか
---
https://feedforce.slack.com/archives/CA0CDSLLW/p1532050666000141 

やったこと
---
- `rack-cors` のインストール
- `config/initializers/cors.rb` の設定

参考: [Rails 5 の API モードのイニシャライザーで CORS に対応する](https://qiita.com/takuya0301/items/facf2f81b8d3e0929cf6)

動作確認
---
コード確認のみ

その他
---
- 研修用アプリケーションのため全てのオリジンからのアクセスを許可しています。