### PR TITLE
todo を削除できるようにする

### DIFF
--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -21,6 +21,12 @@ class TodosController < ApplicationController
     render json: todo
   end
 
+  def destroy
+    todo = Todo.find(params[:id])
+    todo.destroy!
+    render json: todo
+  end
+
   private
 
   def todo_params

--- a/spec/requests/todo_spec.rb
+++ b/spec/requests/todo_spec.rb
@@ -122,4 +122,26 @@ RSpec.describe TodosController, type: :request do
         .to change { Todo.find(todo.id).text }.from(todo.text).to(params[:text])
     end
   end
+
+  describe 'DELETE #destroy' do
+    let!(:todo) { FactoryBot.create(:todo) }
+
+    it 'HTTP ステータスコード 200 を返すこと' do
+      delete "/todos/#{todo.id}"
+      expect(response.status).to eq 200
+    end
+
+    it 'DELETE した todo の内容を正しく JSON 形式で返すこと' do
+      delete "/todos/#{todo.id}"
+      json = JSON.parse(response.body)
+      expect(json['id']).to eq todo.id
+      expect(json['title']).to eq todo.title
+      expect(json['text']).to eq todo.text
+      expect(json['created_at']).to eq todo.created_at.as_json
+    end
+
+    it 'todo が削除されること' do
+      expect { delete "/todos/#{todo.id}" }.to change { Todo.count }.by(-1)
+    end
+  end
 end


### PR DESCRIPTION
なぜやるか
---
Closes #7 

やったこと
---
- TodosController に `destroy` アクションを追加
- todo 削除機能のテストを追加
  - Request spec に TodosController の `destroy` アクションのテストを追加

動作確認
---
1. `$ bin/setup` でアプリケーションを初期化 & 動作確認用の todo を作成
2. `$ bin/rails s`でサーバーを起動する
3. 以下の curl コマンドを実行し、 期待する値が返ってくることを確認する( `id` と `created_at` の値は変わります)

``` 
# GET /todos
$ curl -X GET "http://localhost:3000/todos" -H "accept: application/json" | jq
[
  {
    "id": "506a3567-05f7-4c95-94ff-b665957c6597",
    "title": "title_0",
    "text": "text_0",
    "created_at": "2018-07-20T09:40:07.586Z"
  },
  {
    "id": "96880707-0357-4b1f-b5ac-7796f70a9499",
    "title": "title_1",
    "text": "text_1",
    "created_at": "2018-07-20T09:40:07.594Z"
  },
  {
    "id": "aacdc44f-6a5e-4e75-8912-fe929864cd82",
    "title": "title_2",
    "text": "text_2",
    "created_at": "2018-07-20T09:40:07.597Z"
  }
]

# DELETE /todos/{todo_id} <- {todo_id} には 先ほど GET して見た中から任意の todo の id を入れる、この例であれば 'aacdc44f-6a5e-4e75-8912-fe929864cd82' を入れるので以下のコマンドになる
$ curl -X DELETE "http://localhost:3000/todos/aacdc44f-6a5e-4e75-8912-fe929864cd82" -H "accept: application/json" | jq
{
  "id": "aacdc44f-6a5e-4e75-8912-fe929864cd82",
  "title": "title_2",
  "text": "text_2",
  "created_at": "2018-07-20T09:40:07.597Z"
}

# GET /todos
$ curl -X GET "http://localhost:3000/todos" -H "accept: application/json" | jq
[
  {
    "id": "506a3567-05f7-4c95-94ff-b665957c6597",
    "title": "title_0",
    "text": "text_0",
    "created_at": "2018-07-20T09:40:07.586Z"
  },
  {
    "id": "96880707-0357-4b1f-b5ac-7796f70a9499",
    "title": "title_1",
    "text": "text_1",
    "created_at": "2018-07-20T09:40:07.594Z"
  }
]
```